### PR TITLE
Add Variant and SelectedVar API

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -67,7 +67,7 @@ export default defineConfig({
     ],
 
     socialLinks: [
-      { icon: "github", link: "https://github.com/TockePie/db_labs" },
+      { icon: "github", link: "https://github.com/Vitvor-ua/db_labs" },
     ],
   },
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "homepage": "https://tockepie.github.io/db_labs",
+  "homepage": "https://Vitvor-ua.github.io/db_labs",
   "name": "edu_db_labs",
   "version": "2.1.0",
   "main": "index.js",

--- a/src/api/prisma/schema.prisma
+++ b/src/api/prisma/schema.prisma
@@ -36,3 +36,19 @@ model Type {
 
   question Question @relation(fields: [question_id], references: [id], onDelete: Cascade)
 }
+model Variant {
+  id          String  @id @unique @default(uuid())
+  question_id String
+  text        String  @db.Text
+
+  question     Question    @relation(fields: [question_id], references: [id], onDelete: Cascade)
+  selectedVars SelectedVar[]
+}
+
+model SelectedVar {
+  id         String  @id @unique @default(uuid())
+  variant_id String
+  answer_id  String
+
+  variant Variant @relation(fields: [variant_id], references: [id], onDelete: Cascade)
+}

--- a/src/api/src/index.ts
+++ b/src/api/src/index.ts
@@ -6,6 +6,8 @@ import morgan from 'morgan'
 
 import questionRouter from './routes/question.js'
 import typeRouter from './routes/type.js'
+import variantRouter from './routes/variant.js'
+import selectedVarRouter from './routes/selectedVar.js'
 
 const PORT = process.env.PORT ?? 3000
 const app = express()
@@ -15,6 +17,8 @@ app.use(morgan('combined'))
 
 app.use(questionRouter)
 app.use(typeRouter)
+app.use(variantRouter)
+app.use(selectedVarRouter)
 
 app.get('/', (_: Request, res: Response) => {
   res.json({ message: 'Welcome to the Express + TypeScript Server!' })

--- a/src/api/src/routes/selectedVar.ts
+++ b/src/api/src/routes/selectedVar.ts
@@ -1,0 +1,74 @@
+import { SelectedVar } from '#generated/prisma/index.js'
+import prisma from '#prisma.js'
+import { Request, Response, Router } from 'express'
+
+const router = Router()
+
+router.get('/selectedvar', async (_: Request, res: Response) => {
+  const selected = await prisma.selectedVar.findMany()
+
+  if (selected.length === 0) {
+    res.status(404).json({ message: 'No selected variants found' })
+    return
+  }
+
+  res.status(200).json(selected)
+})
+
+router.get('/selectedvar/:id', async (req: Request, res: Response) => {
+  const selected = await prisma.selectedVar.findUnique({
+    where: { id: req.params.id }
+  })
+
+  if (!selected) {
+    res.status(404).json({ message: 'Selected variant not found' })
+    return
+  }
+
+  res.status(200).json(selected)
+})
+
+router.post('/selectedvar', async (req: Request, res: Response) => {
+  const { variant_id, answer_id } = req.body as SelectedVar
+
+  if (!variant_id || !answer_id) {
+    res.status(400).json({ message: 'Missing required fields' })
+    return
+  }
+
+  const selected = await prisma.selectedVar.create({
+    data: { variant_id, answer_id }
+  })
+
+  res.status(201).json(selected)
+})
+
+router.put('/selectedvar/:id', async (req: Request, res: Response) => {
+  const { variant_id, answer_id } = req.body as SelectedVar
+
+  const selected = await prisma.selectedVar.update({
+    data: { variant_id, answer_id },
+    where: { id: req.params.id }
+  })
+
+  res.status(200).json(selected)
+})
+
+router.delete('/selectedvar/:id', async (req: Request, res: Response) => {
+  const selected = await prisma.selectedVar.findUnique({
+    where: { id: req.params.id }
+  })
+
+  if (!selected) {
+    res.status(404).json({ message: 'Selected variant not found' })
+    return
+  }
+
+  const deleted = await prisma.selectedVar.delete({
+    where: { id: req.params.id }
+  })
+
+  res.status(200).json(deleted)
+})
+
+export default router

--- a/src/api/src/routes/variant.ts
+++ b/src/api/src/routes/variant.ts
@@ -1,0 +1,88 @@
+import { Variant } from '#generated/prisma/index.js'
+import prisma from '#prisma.js'
+import { Request, Response, Router } from 'express'
+
+const router = Router()
+
+router.get('/variant', async (_: Request, res: Response) => {
+  const variants = await prisma.variant.findMany()
+
+  if (variants.length === 0) {
+    res.status(404).json({ message: 'No variants found' })
+    return
+  }
+
+  res.status(200).json(variants)
+})
+
+router.get('/variant/:id', async (req: Request, res: Response) => {
+  const variant = await prisma.variant.findUnique({
+    where: {
+      id: req.params.id
+    }
+  })
+
+  if (!variant) {
+    res.status(404).json({ message: 'Variant not found' })
+    return
+  }
+
+  res.status(200).json(variant)
+})
+
+router.post('/variant', async (req: Request, res: Response) => {
+  const { question_id, text } = req.body as Variant
+
+  if (!question_id || !text) {
+    res.status(400).json({ message: 'Missing required fields' })
+    return
+  }
+
+  const variant = await prisma.variant.create({
+    data: {
+      question_id,
+      text
+    }
+  })
+
+  res.status(201).json(variant)
+})
+
+router.put('/variant/:id', async (req: Request, res: Response) => {
+  const { question_id, text } = req.body as Variant
+
+  const variant = await prisma.variant.update({
+    data: {
+      question_id,
+      text
+    },
+    where: {
+      id: req.params.id
+    }
+  })
+
+  res.status(200).json(variant)
+})
+
+router.delete('/variant/:id', async (req: Request, res: Response) => {
+  const variant = await prisma.variant.findUnique({
+    where: {
+      id: req.params.id
+    }
+  })
+
+  if (!variant) {
+    res.status(404).json({ message: 'Variant not found' })
+    return
+  }
+
+  const deletedVariant = await prisma.variant.delete({
+    where: {
+      id: req.params.id
+    }
+  })
+
+  res.status(200).json(deletedVariant)
+})
+
+export default router


### PR DESCRIPTION
## Summary
- update homepage and GitHub link for docs
- extend Prisma schema with Variant and SelectedVar models
- add CRUD routes for Variant and SelectedVar
- register new routes in API server

## Testing
- `npm run docs:dev`


------
https://chatgpt.com/codex/tasks/task_e_68422e189660832f8700210021e38992