### PR TITLE
Switch API to npm usage

### DIFF
--- a/docs/test/README.md
+++ b/docs/test/README.md
@@ -10,13 +10,13 @@ outline: deep
 ### 1. Встановити залежнсті проекту
 
 ```bash
-yarn
+npm install
 ```
 
 ### 2. Запустити сервер
 
 ```bash
-yarn run start:dev
+npm run start:dev
 ```
 
 ## Перевірка працездатности сервісів

--- a/src/api/.env
+++ b/src/api/.env
@@ -1,0 +1,2 @@
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/db
+PORT=3000

--- a/src/api/.gitignore
+++ b/src/api/.gitignore
@@ -1,5 +1,6 @@
 # Environment variables
 .env
+!.env
 .env.*
 !.env.example
 

--- a/src/api/package.json
+++ b/src/api/package.json
@@ -10,7 +10,8 @@
     "type-check": "tsc --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "start": "node --env-file .env dist/index.js"
   },
   "imports": {
     "#*": "./src/*",
@@ -37,5 +38,5 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.32.0"
   },
-  "packageManager": "yarn@4.9.1"
+  "packageManager": "npm@11.4.1"
 }


### PR DESCRIPTION
## Summary
- configure API package for npm usage
- provide default `.env` file
- document npm-based setup in testing docs

## Testing
- `npm run start:dev` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_684244696bac832f8168544cba6bde8b