### PR TITLE
Fix missing Prisma relation

### DIFF
--- a/src/api/prisma/schema.prisma
+++ b/src/api/prisma/schema.prisma
@@ -27,6 +27,7 @@ model Question {
 
   quiz  Quiz   @relation(fields: [quiz_id], references: [id], onDelete: Cascade)
   types Type[]
+  variants Variant[] // Added reverse relation for Variant.question
 }
 
 model Type {


### PR DESCRIPTION
## Summary
- add variants field to `Question` model for reverse relation
- ensure prisma schema validates

## Testing
- `npx --yes prisma generate`

------
https://chatgpt.com/codex/tasks/task_e_68424dbc4278832fb80654e4d9b399c5